### PR TITLE
Open GitHub Link in a New Tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
                 </div>
             </div>
         </div>
-        <a id="footer" href="https://github.com/devgg/FontIcon">
+        <a id="footer" href="https://github.com/devgg/FontIcon" target="_blank">
         <i class="fab fa-github"></i>
         View on GitHub
     </a>


### PR DESCRIPTION
Found `fonticon` through [Reddit](https://www.reddit.com/r/webdev/comments/8rl079/showoff_saturday_i_made_an_online_favicon_creator/) and me / my team at work really love this.

Went to 👀 your code via GitHub and saw it open on the same page. Opening up this super small PR to fix that, as navigating to the GitHub repository on the same tab made me lose the icon I had been building after playing around for a bit. Cheers!